### PR TITLE
fixed unit tests, added event and awaited the response

### DIFF
--- a/test/delete-task.test.js
+++ b/test/delete-task.test.js
@@ -1,6 +1,13 @@
-const deleteTask = require('../source/delete-task');
+const deleteTask = require("../source/delete-task");
 
-test('testing delete', () => {
-    const resp = deleteTask.handler({});
-    expect(resp).not.toBeNull();
-  });
+const testEvent = {
+  requestContext: {
+    authorizer: {},
+  },
+  body: '{ "someAttribute" : "some value" }',
+};
+
+test("testing delete", async () => {
+  const resp = await deleteTask.handler(testEvent);
+  expect(resp).not.toBeNull();
+});

--- a/test/get-task.test.js
+++ b/test/get-task.test.js
@@ -1,6 +1,13 @@
-const getTask = require('../source/get-task');
+const getTask = require("../source/get-task");
 
-test('testing get', () => {
-    const resp = getTask.handler({});
-    expect(resp).not.toBeNull();
-  });
+const testEvent = {
+  requestContext: {
+    authorizer: {},
+  },
+  body: '{ "someAttribute" : "some value" }',
+};
+
+test("testing get", async () => {
+  const resp = await getTask.handler(testEvent);
+  expect(resp).not.toBeNull();
+});

--- a/test/post-task.test.js
+++ b/test/post-task.test.js
@@ -1,6 +1,13 @@
-const postTask = require('../source/post-task');
+const postTask = require("../source/post-task");
 
-test('testing post', () => {
-    const resp = postTask.handler({});
-    expect(resp).not.toBeNull();
-  });
+const testEvent = {
+  requestContext: {
+    authorizer: {},
+  },
+  body: '{ "someAttribute" : "some value" }',
+};
+
+test("testing post", async () => {
+  const resp = await postTask.handler(testEvent);
+  expect(resp).not.toBeNull();
+});

--- a/test/put-task.test.js
+++ b/test/put-task.test.js
@@ -1,6 +1,13 @@
-const putTask = require('../source/put-task');
+const putTask = require("../source/put-task");
 
-test('testing puts', () => {
-    const resp = putTask.handler({});
-    expect(resp).not.toBeNull();
-  });
+const testEvent = {
+  requestContext: {
+    authorizer: {},
+  },
+  body: '{ "someAttribute" : "some value" }',
+};
+
+test("testing puts", async () => {
+  const resp = await putTask.handler(testEvent);
+  expect(resp).not.toBeNull();
+});


### PR DESCRIPTION
@BrandtBasaran take a close look at my changes to get tests to await the handler responses, also how I added a valid "event" object to the tests.  These changes made the code coverage 100%.  But the tests still aren't really testing much useful.  The next step will be to "mock" the call to dynamo and make the test more useful.

Once you review and understand the changes, complete this pull request